### PR TITLE
添加GitHub 加速代理配置

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -247,6 +247,13 @@ sys_dashboard() {
         done_count=$(wc -l < "$STATE_FILE")
         echo -e "${H_BLUE}║${NC} ${BOLD}Progress${NC} : Resuming ($done_count steps recorded)"
     fi
+    
+    if [ -f "/tmp/shorin_github_proxy" ]; then
+        local proxy_url
+        proxy_url=$(cat /tmp/shorin_github_proxy)
+        echo -e "${H_BLUE}║${NC} ${BOLD}GitHub${NC}   : ${H_GREEN}Proxy Enabled${NC} ${DIM}(${proxy_url})${NC}"
+    fi
+    
     echo -e "${H_BLUE}╚══════════════════════════════════════════════════════╝${NC}"
     echo ""
 }
@@ -255,6 +262,7 @@ sys_dashboard() {
 
 select_desktop
 select_optional_modules
+select_github_proxy
 clear
 show_banner
 sys_dashboard
@@ -296,6 +304,8 @@ CURRENT_STEP=0
 
 log "Initializing installer sequence..."
 sleep 0.5
+
+apply_github_proxy
 
 # --- Reflector Mirror Update (State Aware) ---
 section "Pre-Flight" "Mirrorlist Optimization"

--- a/scripts/00-utils.sh
+++ b/scripts/00-utils.sh
@@ -157,6 +157,7 @@ detect_target_user() {
     # 4. 最终验证与持久化
     echo "$TARGET_USER" > "/tmp/shorin_install_user"
     HOME_DIR="/home/$TARGET_USER"
+    
     export TARGET_USER HOME_DIR
 }
 
@@ -578,4 +579,105 @@ setup_ly() {
     systemctl enable ly@tty1
     
     success "ly display manager has been successfully configured!"
+}
+
+# ==============================================================================
+# select_github_proxy - 交互式选择 GitHub 加速代理并测试连通性
+# ==============================================================================
+select_github_proxy() {
+    local names=(
+        "EdgeOne (Global)"
+        "HK Node"
+        "Global Node"
+        "LLKK Node"
+    )
+    local urls=(
+        "https://edgeone.gh-proxy.com"
+        "https://hk.gh-proxy.com"
+        "https://gh-proxy.com"
+        "https://gh.llkk.cc"
+    )
+    
+    local test_url="https://raw.githubusercontent.com/SHORiN-KiWATA/shorin-arch-setup/main/README.md"
+    
+    while true; do
+        echo ""
+        echo -e "${H_PURPLE}╭──────────────────────────────────────────────────────────────╮${NC}"
+        echo -e "${H_PURPLE}│${NC} ${BOLD}Select GitHub Acceleration Proxy${NC}"
+        echo -e "${H_PURPLE}╰──────────────────────────────────────────────────────────────╯${NC}"
+        echo ""
+        
+        for i in "${!names[@]}"; do
+            local display_idx=$((i+1))
+            echo -e "   ${H_CYAN}[${display_idx}]${NC} ${names[$i]} ${DIM}(${urls[$i]})${NC}"
+        done
+        echo -e "   ${H_CYAN}[0]${NC} ${H_RED}Skip / No Proxy${NC}"
+        echo ""
+        
+        local choice
+        read -t 60 -p "$(echo -e "   ${H_YELLOW}Enter choice [0-4] (Default 0): ${NC}")" choice
+        if [ $? -ne 0 ]; then echo ""; fi
+        choice=${choice:-0}
+        
+        if [[ "$choice" == "0" ]]; then
+            log "No GitHub proxy selected."
+            return 0
+        fi
+        
+        if ! [[ "$choice" =~ ^[1-4]$ ]]; then
+            warn "Invalid choice. Please enter 0-4."
+            continue
+        fi
+        
+        local index=$((choice-1))
+        local selected_name="${names[$index]}"
+        local selected_url="${urls[$index]}"
+        
+        log "Testing connectivity for ${H_CYAN}${selected_name}${NC} ..."
+        
+        if ! command -v curl &>/dev/null; then
+            warn "curl is not available. Skipping proxy test."
+            echo "$selected_url" > /tmp/shorin_github_proxy
+            export GH_PROXY_URL="$selected_url"
+            break
+        fi
+        
+        local test_result
+        test_result=$(curl -s -o /dev/null -w "%{http_code}|%{time_total}" --max-time 10 -L "${selected_url}/${test_url}" 2>/dev/null)
+        
+        local http_code="${test_result%%|*}"
+        local latency="${test_result##*|}"
+        
+        if [[ "$http_code" == "200" ]]; then
+            success "Proxy reachable. Latency: ${latency}s"
+            echo "$selected_url" > /tmp/shorin_github_proxy
+            export GH_PROXY_URL="$selected_url"
+            break
+        else
+            warn "Proxy test failed (HTTP: ${http_code:-timeout}, ${latency:-N/A}s)."
+            local retry
+            read -t 20 -p "$(echo -e "   ${H_YELLOW}Try another proxy? [Y/n]: ${NC}")" retry
+            if [ $? -ne 0 ]; then echo ""; fi
+            retry=${retry:-Y}
+            if [[ "$retry" =~ ^[Nn]$ ]]; then
+                log "Skipping GitHub proxy configuration."
+                return 0
+            fi
+        fi
+    done
+}
+
+# ==============================================================================
+# apply_github_proxy - 应用已选择的 GitHub 代理到当前环境
+# ==============================================================================
+apply_github_proxy() {
+    if [[ -f "/tmp/shorin_github_proxy" ]]; then
+        local proxy_url
+        proxy_url=$(cat /tmp/shorin_github_proxy)
+        if [[ -n "$proxy_url" ]]; then
+            git config --system url."${proxy_url}/https://github.com/".insteadOf "https://github.com/" &>/dev/null
+            export GH_PROXY_URL="$proxy_url"
+            log "GitHub proxy applied: ${H_GREEN}${proxy_url}${NC}"
+        fi
+    fi
 }


### PR DESCRIPTION
我曾经在使用这个脚本时遇到过GitHub 直连超时或中断，导致安装失败。故我添加了Github的代理配置。
（以下为AI生成的内容）
## 具体修改

### 1. `scripts/00-utils.sh`

**新增 `select_github_proxy()` 函数**
- 提供 4 个候选代理地址：
  - `https://edgeone.gh-proxy.com`
  - `https://hk.gh-proxy.com`
  - `https://gh-proxy.com`
  - `https://gh.llkk.cc`
- 支持 `[0] Skip / No Proxy` 跳过
- 用户选择后，自动使用 `curl` 对 `raw.githubusercontent.com` 上的真实资源进行连通性测试（检测 HTTP 200 与延迟）
- 测试失败时提示具体状态码/超时信息，并询问是否重选其他代理
- 选择结果持久化到 `/tmp/shorin_github_proxy`，并导出 `GH_PROXY_URL` 环境变量

**新增 `apply_github_proxy()` 函数**
- 读取持久化的代理配置
- 通过 `git config --system url."<proxy>/https://github.com/".insteadOf "https://github.com/"` 设置**系统级 Git URL 重写规则**
- **优势**：所有用户（root 及后续创建的目标用户）的 `git clone https://github.com/...` 都会自动被重写到代理地址，无需逐行修改现有脚本中的 git 命令

### 2. `install.sh`

- 在 `select_optional_modules` 之后新增 `select_github_proxy` 调用，让用户在正式安装前完成代理配置
- 在 `sys_dashboard()` 的系统概览面板中新增 **GitHub Proxy** 状态行，直观显示当前是否启用了代理
- 在模块循环开始前的 Pre-Flight 阶段调用 `apply_github_proxy()`，确保后续所有涉及 GitHub 的脚本模块自动生效

### 工作流程示意
选择桌面 → 选择可选模块 → 选择 GitHub 代理（新增） → 系统概览 Dashboard（显示代理状态） → 应用代理（新增） → 继续安装...

### 测试说明

`bash -n` 语法检查已通过（`00-utils.sh`、`install.sh`）但未经过实机测试